### PR TITLE
Add --link-only flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Introduce GitHub Actions for push and pull\_request ([#27]), courtesy of [@sanxiyn].
 - Some refactorings to clean up the implementation.
 
+## [0.1.9] - 2020-10-25
+### Added
+- Add link-only option
+
 ## [0.1.8] - 2019-12-15
 ### Security
 - Remove reliance on dependencies with known vulnerabilities.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,7 +615,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "linky"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "bytecount 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linky"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Mattias Päivärinta <mattias@paivarinta.se>"]
 description = "Extract links from Markdown files and check links for brokenness"
 repository = "https://github.com/mattias-p/linky"

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,10 @@ use structopt::StructOpt;
 #[derive(StructOpt, Debug)]
 /// Extract links from Markdown files and check links for brokenness.
 struct Opt {
+    #[structopt(long = "link-only", short = "l")]
+    /// Print only links
+    link_only: bool,
+
     #[structopt(long = "check", short = "c")]
     /// Check links
     check: bool,
@@ -144,6 +148,7 @@ fn print_result(
     record: &Record,
     res: &Option<Result<(), Arc<error::Error>>>,
     silence: &HashSet<&Tag>,
+    link_only: bool,
 ) {
     let tag = res
         .as_ref()
@@ -155,15 +160,19 @@ fn print_result(
                 warn!("{}", line);
             }
         }
-        println!(
-            "{}:{}: {} {}",
-            record.doc_path.to_string_lossy(),
-            record.doc_line,
-            tag.as_ref()
-                .map(|tag| tag as &dyn fmt::Display)
-                .unwrap_or(&"" as &dyn fmt::Display),
-            record.link
-        );
+        if link_only {
+          println!("{}", record.link);
+        } else {
+          println!(
+              "{}:{}: {} {}",
+              record.doc_path.to_string_lossy(),
+              record.doc_line,
+              tag.as_ref()
+                  .map(|tag| tag as &dyn fmt::Display)
+                  .unwrap_or(&"" as &dyn fmt::Display),
+              record.link
+          );
+        }
     }
 }
 
@@ -188,7 +197,7 @@ fn main() {
         heap: Mutex::new(BinaryHeap::new()),
         current: atomic::AtomicUsize::new(0),
         f: |(record, res)| {
-            print_result(&record, &res, &silence);
+            print_result(&record, &res, &silence, opt.link_only);
         },
     };
 


### PR DESCRIPTION
Add a `--link-only` flag to make comparing links within markdown files easier e.g. using [zet](https://github.com/yarrow/zet) (CLI utility to find the union, intersection, set difference, etc of files considered as sets of lines).

Sometimes I just want to make sure that all of the links contained within one file are present in another.